### PR TITLE
support new version of grunt that no longer has a build in error handler

### DIFF
--- a/tasks/it.js
+++ b/tasks/it.js
@@ -42,12 +42,22 @@ module.exports = function (grunt) {
                 require(f);
             });
             it.run().then(function (results) {
-                if (oToString(results) === "[object Number]") {
-                    done(0 === results);
-                } else {
-                    done(results.errorCount === 0 &&
-                        results.totalCount === (results.successCount + results.skippedCount) &&
-                        results.pendingCount === 0);
+                // support "no tests found"
+                if (results === undefined) {
+                    return done(true);
+                }
+
+                try {
+                    if (oToString(results) === "[object Number]") {
+                        done(0 === results);
+                    } else {
+                        done(results.errorCount === 0 &&
+                            results.totalCount === (results.successCount + results.skippedCount) &&
+                            results.pendingCount === 0);
+                    }
+                } catch (error) {
+                    console.error(error);
+                    done(false);
                 }
             });
         }


### PR DESCRIPTION
Updating this to support a new version of grunt added in with https://github.com/C2FO/c2fo/pull/4408

The grunt's `registerMultiTask` used to have an error handler and it was removed at some point. We were getting an error when running the tests for folders without an actual test file, such as `grunt it:bus`. 

```shell
$ grunt it:bus                                                                                                                                                               
Running "it:bus" (it) task
No Tests found
results124412412142: undefined
[TypeError: Cannot read property 'errorCount' of undefined]
```

This PR is aimed to fix that issue and add our own error catcher to hopefully prevent future issues.

## Testing

Link this module with `npm link` and run the c2fo test suite locally.

* `$ cd grunt-it && npm link`
* `$ cd $C2FO_HOME && npm link grunt-it`